### PR TITLE
seperate boolean casting from projection

### DIFF
--- a/src/svm/value.h
+++ b/src/svm/value.h
@@ -104,8 +104,7 @@ static inline bool asBoolean (VMState, Value, const char *file, int line);
 #define AS_CLOSURE(VM, V)    asClosure_   ((VM), (V), __FILE__, __LINE__)
 #define AS_VMFUNCTION(VM, V) asVMFunction_((VM), (V), __FILE__, __LINE__)
 #define AS_VMSTRING(VM, V)   asVMString_  ((VM), (V), __FILE__, __LINE__)
-
-#define AS_BOOLEAN(VM, V)    asBoolean    ((VM), (V), __FILE__, __LINE__)
+#define AS_BOOLEAN(VM, V)    asBoolean_    ((VM), (V), __FILE__, __LINE__)
 
 // additional observers for values
 
@@ -209,17 +208,10 @@ static inline struct VMString *asVMString_(VMState vm, Value v, const char *file
     typeerror(vm, "a string", v, file, line);
   return GCVALIDATE(v.s);
 }
-
-static inline bool asBoolean(VMState vm, Value v, const char *file, int line) {
-  if (v.tag == Boolean)
-      return v.b;
-  if (v.tag == Number) {
-      if (v.n == 0)
-          return false;
-      else
-          return true;
-  }
-  typeerror(vm, "only number can be casted", v, file, line);
+static inline bool asBoolean_(VMState vm, Value v, const char *file, int line) {
+  if (v.tag != Boolean)
+    typeerror(vm, "only number can be casted", v, file, line);
+  return v.b;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/svm/vmrun.c
+++ b/src/svm/vmrun.c
@@ -66,11 +66,8 @@ void vmrun(VMState vm, struct VMFunction *fun) {
                 vm->registers[uX(curr_inst)] = mkNumberValue(0);
                 break;
             case AsBool:
-                // examines the Value in uX and make it a boolean Value
-                // only cast int to bool, and 0 is false, others are true
-                vm->registers[uX(curr_inst)] =
-                    mkBooleanValue(AS_BOOLEAN(vm, 
-                                              vm->registers[uX(curr_inst)]));
+                // put the truthiness of the value in uY in uX
+                assert(0); // TODO
                 break;
             case Not:
                 // need to implement our own ASBOOLEAN projection function
@@ -81,7 +78,7 @@ void vmrun(VMState vm, struct VMFunction *fun) {
                     mkBooleanValue(!AS_BOOLEAN(vm, vm->registers[uX(curr_inst)]));
                 break;
         }
-        ++vm->pc;
+        ++vm->pc; // advance the program counter
     }
 
   return;


### PR DESCRIPTION
Having asBoolean_ cast for us in special circumstances seems like a violation of the standard set by the rest of the asX functions. I propose that asBoolean_ simply retrieve a boolean value and instruction AsBool perform a cast. Thus any boolean logic instructions can just call the AS_BOOLEAN macro and assume that the register contents are bool.